### PR TITLE
Build audio HAL from source and cleanup proprietary-files

### DIFF
--- a/audio/audio_effects.conf
+++ b/audio/audio_effects.conf
@@ -1,3 +1,22 @@
+#
+# This file was modified by Dolby Laboratories, Inc. The portions of the
+# code that are surrounded by "DOLBY..." are copyrighted and
+# licensed separately, as follows:
+#
+#  (C) 2012-2016 Dolby Laboratories, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 # List of effect libraries to load. Each library element must contain a "path" element
 # giving the full path of the library .so file.
 #    libraries {
@@ -6,26 +25,31 @@
 #        }
 #    }
 libraries {
+# This is a proxy library that will be an abstraction for
+# the HW and SW effects
+
+  #proxy {
+    #path /system/lib/soundfx/libeffectproxy.so
+  #}
+
+# This is the SW implementation library of the effect
+  #libSW {
+    #path /system/lib/soundfx/libswwrapper.so
+  #}
+
+# This is the HW implementation library for the effect
+  #libHW {
+    #path /system/lib/soundfx/libhwwrapper.so
+  #}
+
   bundle {
     path /system/lib/soundfx/libbundlewrapper.so
   }
   reverb {
     path /system/lib/soundfx/libreverbwrapper.so
   }
-  qcbassboost {
-    path /vendor/lib/soundfx/libqcbassboost.so
-  }
-  qcvirt {
-    path /vendor/lib/soundfx/libqcvirt.so
-  }
-  qcreverb {
-    path /vendor/lib/soundfx/libqcreverb.so
-  }
-  visualizer_sw {
+  visualizer {
     path /system/lib/soundfx/libvisualizer.so
-  }
-  visualizer_hw {
-    path /system/lib/soundfx/libqcomvisualizer.so
   }
   downmix {
     path /system/lib/soundfx/libdownmix.so
@@ -33,15 +57,14 @@ libraries {
   loudness_enhancer {
     path /system/lib/soundfx/libldnhncr.so
   }
-  proxy {
-    path /system/lib/soundfx/libeffectproxy.so
+#DOLBY_ENABLE
+  dap_sw {
+    path /system/vendor/lib/soundfx/libswdap.so
   }
-  offload_bundle {
-    path /system/lib/soundfx/libqcompostprocbundle.so
+  dap_hw {
+    path /system/vendor/lib/soundfx/libhwdap.so
   }
-  audio_pre_processing {
-    path /system/lib/soundfx/libqcomvoiceprocessing.so
-  }
+#DOLBY_END
   dirac {
     path /system/lib/soundfx/libdirac.so
   }
@@ -93,141 +116,65 @@ effects {
   #} End of effect proxy
 
   bassboost {
-    library proxy
-    uuid 14804144-a5ee-4d24-aa88-0002a5d5c51b
-
-    libsw {
-      library qcbassboost
-      uuid 23aca180-44bd-11e2-bcfd-0800200c9a66
-    }
-
-    libhw {
-      library offload_bundle
-      uuid 2c4a8c24-1581-487f-94f6-0002a5d5c51b
-    }
+    library bundle
+    uuid 8631f300-72e2-11df-b57e-0002a5d5c51b
   }
   virtualizer {
-    library proxy
-    uuid d3467faa-acc7-4d34-acaf-0002a5d5c51b
-
-    libsw {
-      library qcvirt
-      uuid e6c98a16-22a3-11e2-b87b-f23c91aec05e
-    }
-
-    libhw {
-      library offload_bundle
-      uuid 509a4498-561a-4bea-b3b1-0002a5d5c51b
-    }
+    library bundle
+    uuid 1d4033c0-8557-11df-9f2d-0002a5d5c51b
   }
   equalizer {
-    library proxy
-    uuid c8e70ecd-48ca-456e-8a4f-0002a5d5c51b
-
-    libsw {
-      library bundle
-      uuid ce772f20-847d-11df-bb17-0002a5d5c51b
-    }
-
-    libhw {
-      library offload_bundle
-      uuid a0dac280-401c-11e3-9379-0002a5d5c51b
-    }
+    library bundle
+    uuid ce772f20-847d-11df-bb17-0002a5d5c51b
   }
   volume {
     library bundle
     uuid 119341a0-8469-11df-81f9-0002a5d5c51b
   }
   reverb_env_aux {
-    library proxy
-    uuid 48404ac9-d202-4ccc-bf84-0002a5d5c51b
-
-    libsw {
-      library qcreverb
-      uuid a8c1e5f3-293d-43cd-95ec-d5e26c02e217
-    }
-
-    libhw {
-      library offload_bundle
-      uuid 79a18026-18fd-4185-8233-0002a5d5c51b
-    }
+    library reverb
+    uuid 4a387fc0-8ab3-11df-8bad-0002a5d5c51b
   }
   reverb_env_ins {
-    library proxy
-    uuid b707403a-a1c1-4291-9573-0002a5d5c51b
-
-    libsw {
-      library qcreverb
-      uuid 791fff8b-8129-4655-83a4-59bc61034c3a
-    }
-
-    libhw {
-      library offload_bundle
-      uuid eb64ea04-973b-43d2-8f5e-0002a5d5c51b
-    }
+    library reverb
+    uuid c7a511a0-a3bb-11df-860e-0002a5d5c51b
   }
   reverb_pre_aux {
-    library proxy
-    uuid 1b78f587-6d1c-422e-8b84-0002a5d5c51b
-
-    libsw {
-      library qcreverb
-      uuid 53ef1db5-c0c0-445b-b060-e34d20ebb70a
-    }
-
-    libhw {
-      library offload_bundle
-      uuid 6987be09-b142-4b41-9056-0002a5d5c51b
-    }
+    library reverb
+    uuid f29a1400-a3bb-11df-8ddc-0002a5d5c51b
   }
   reverb_pre_ins {
-    library proxy
-    uuid f3e178d2-ebcb-408e-8357-0002a5d5c51b
-
-    libsw {
-      library qcreverb
-      uuid b08a0e38-22a5-11e2-b87b-f23c91aec05e
-    }
-
-    libhw {
-      library offload_bundle
-      uuid aa2bebf6-47cf-4613-9bca-0002a5d5c51b
-    }
+    library reverb
+    uuid 172cdf00-a3bc-11df-a72f-0002a5d5c51b
   }
   visualizer {
-    library proxy
-    uuid 1d0a1a53-7d5d-48f2-8e71-27fbd10d842c
-
-    libsw {
-      library visualizer_sw
-      uuid  d069d9e0-8329-11df-9168-0002a5d5c51b
-    }
-
-    libhw {
-      library visualizer_hw
-      uuid 7a8044a0-1a71-11e3-a184-0002a5d5c51b
-    }
+    library visualizer
+    uuid d069d9e0-8329-11df-9168-0002a5d5c51b
   }
   downmix {
     library downmix
     uuid 93f04452-e4fe-41cc-91f9-e475b6d1d69f
   }
-  hw_acc {
-    library offload_bundle
-    uuid 7d1580bd-297f-4683-9239-e475b6d1d69f
-  }
   loudness_enhancer {
     library loudness_enhancer
     uuid fa415329-2034-4bea-b5dc-5b381c8d1e2c
   }
-  aec {
-    library audio_pre_processing
-    uuid 0f8d0d2a-59e5-45fe-b6e4-248c8a799109
+#DOLBY_ENABLE
+  dap {
+    library proxy
+    uuid 9d4921da-8225-4f29-aefa-39537a04bcaa
+
+    libsw {
+      library dap_sw
+      uuid 6ab06da4-c516-4611-8166-452799218539
+    }
+
+    libhw {
+      library dap_hw
+      uuid a0c30891-8246-4aef-b8ad-d53e26da0253
+    }
   }
-  ns {
-    library audio_pre_processing
-    uuid 1d97bb0b-9e2f-4403-9ae3-58c2554306f8
-  }
+#DOLBY_END
   dirac {
     library dirac
     uuid e069d9e0-8329-11df-9168-0002a5d5c51b
@@ -291,7 +238,7 @@ global_processing {
       }
     }
   }
- }
+}
 
 # Default pre-processing effects. Add to audio_effect.conf "effects" section if
 # audio HAL implements support for them.
@@ -344,17 +291,6 @@ global_processing {
 #        }
 #        ...
 #    }
-
-# Added aec, ns effects for voice_commuincation, which are supported by the board
-
-pre_processing {
-  voice_communication {
-    aec {
-    }
-    ns  {
-    }
-  }
-}
 
 #
 # TODO: add default audio pre processor configurations after debug and tuning phase

--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -112,6 +112,8 @@
         <device name="SND_DEVICE_OUT_VOIP_SPEAKER" backend="speaker" />
         <device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" backend="speaker-and-headphones" />
         <device name="SND_DEVICE_OUT_SPEAKER_AND_LINE" backend="speaker-and-headphones" />
+        <device name="SND_DEVICE_OUT_HANDSET" backend="speaker"/>
+        <device name="SND_DEVICE_OUT_VOICE_HANDSET" backend="speaker"/>
     </backend_names>
 </audio_platform_info>
 

--- a/audio/audio_policy_volumes.xml
+++ b/audio/audio_policy_volumes.xml
@@ -181,3 +181,4 @@ volume index from 0 to 100.
     <volume stream="AUDIO_STREAM_PATCH" deviceCategory="DEVICE_CATEGORY_EXT_MEDIA"
                                              ref="FULL_SCALE_VOLUME_CURVE"/>
 </volumes>
+

--- a/audio/mixer_paths_mtp.xml
+++ b/audio/mixer_paths_mtp.xml
@@ -1283,8 +1283,8 @@
         <ctl name="RDAC2 MUX" value="RX2" />
         <ctl name="HPHL" value="Switch" />
         <ctl name="HPHR" value="Switch" />
-		<ctl name="RX1 Digital Volume" value="71" />
-		<ctl name="RX2 Digital Volume" value="71" />
+		<ctl name="RX1 Digital Volume" value="84" />
+		<ctl name="RX2 Digital Volume" value="84" />
     </path>
 
     <path name="headset-mic">
@@ -1346,8 +1346,8 @@
     <path name="speaker-and-headphones">
         <path name="speaker" />
         <path name="headphones" />
-        <ctl name="RX1 Digital Volume" value="70" />
-        <ctl name="RX2 Digital Volume" value="70" />
+        <ctl name="RX1 Digital Volume" value="84" />
+        <ctl name="RX2 Digital Volume" value="84" />
     </path>
 
     <path name="wsa-speaker-and-headphones">

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -409,10 +409,6 @@
     <!-- Flag specifying whether WFC over IMS is available on device -->
     <bool name="config_device_wfc_ims_available">true</bool>
 
-    <!-- Support in Surfaceflinger for blur layers.
-         NOTE: This requires additional hardware-specific code. -->
-    <bool name="config_uiBlurEnabled">true</bool>
-
     <!-- Whether notify fingerprint client of successful cancelled authentication -->
     <bool name="config_notifyClientOnFingerprintCancelSuccess">true</bool>
 

--- a/proprietary-files-qc.txt
+++ b/proprietary-files-qc.txt
@@ -293,9 +293,6 @@ vendor/lib64/librs_adreno.so
 vendor/lib64/librs_adreno_sha1.so
 vendor/lib64/libscale.so
 
-# Graphic blur - from op3
-vendor/lib64/libuiblur.so|4b3fabf5ded7c4af531abde681676fc5e9248494
-
 # Graphics firmware
 etc/firmware/a506_zap.b00
 etc/firmware/a506_zap.b01
@@ -502,10 +499,8 @@ vendor/lib/libTimeService.so
 -vendor/lib64/libtime_genoff.so
 vendor/lib64/libTimeService.so
 
-# Widevine - from op3
-vendor/lib/libWVStreamControlAPI_L3.so|61673304827483d44b735a3dd08f0783d10ce92d
-vendor/lib/libwvdrm_L3.so|7e77482481197997294a834bfbc817a01b6075cd
-vendor/lib/mediadrm/libwvdrmengine.so|70419ce1f8eb6bd3aa36234f8d7e8003569efc9c
+# Widevine
+vendor/lib/mediadrm/libwvdrmengine.so
 
 # Wi-Fi
 bin/wcnss_service

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -5,10 +5,6 @@ vendor/lib/rfsa/adsp/libdirac-capiv2.so
 vendor/lib/rfsa/adsp/dirac_resource.dar
 vendor/lib/rfsa/adsp/dirac_resource.so
 
-# Audio
-lib/hw/audio.primary.msm8953.so
-lib64/hw/audio.primary.msm8953.so
-
 # Audio dirac and dolby
 lib/soundfx/libdirac.so
 vendor/lib/libhwdaphal.so

--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -23,8 +23,6 @@ etc/acdbdata/QRD/QRD_Speaker_cal.acdb
 # Camera
 bin/mm-qcamera-app
 bin/mm-qcamera-daemon
-etc/android_model_facea.dat
-etc/android_model_faceg.dat
 etc/sdm_ys_32p_120_21_5_perturb50.bin
 lib/hw/camera.msm8953.so
 lib/libmm-qcamera.so
@@ -39,8 +37,6 @@ lib64/libmorpho_memory_allocator.so
 lib64/libmorpho_panorama.so
 vendor/lib/libChamomilePA.so
 vendor/lib/libFaceGrade.so
-vendor/lib/libFaceProc.so
-vendor/lib/libRecoFace.so
 vendor/lib/libarcsoft_beauty_shot.so
 vendor/lib/libarcsoft_beautyshot.so
 vendor/lib/libarcsoft_beautyshot_image_algorithm.so


### PR DESCRIPTION
Now we're building audio HAL from source. This fixes some bugs in apps like WhatsApp where if you are listening to a voice message via the earpiece and you get a new message, it starts playing via the phone speaker.