### PR TITLE
Fix goodix fingerprint scanner by creating sepolicy set.

### DIFF
--- a/rootdir/ueventd.qcom.rc
+++ b/rootdir/ueventd.qcom.rc
@@ -270,3 +270,10 @@
 
 # lirc
 /dev/lirc0                0660   system     system
+
+#fingerprint
+/dev/goodix_fp        0666   system     system
+
+#add by wuxuefeng for microarray
+/dev/madev0     0666    root    root
+#add end

--- a/sepolicy/device.te
+++ b/sepolicy/device.te
@@ -1,1 +1,2 @@
 type lirc_device, dev_type;
+type gx_fpd_device, dev_type;

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -3,3 +3,4 @@ type fpc_sysfs, fs_type, sysfs_type;
 type netmgrd_data_file, file_type;
 type audio_cal_file, file_type, data_file_type;
 type decrypt_file, file_type;
+type gx_fpd_data_file, file_type, data_file_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -20,3 +20,12 @@
 
 # Ir
 /dev/lirc[0-9]*						u:object_r:lirc_device:s0
+
+# Goodix Fingerprint
+/dev/ttyACM[0-9]*             u:object_r:gx_fpd_device:s0
+/dev/goodix_fp*                    u:object_r:gx_fpd_device:s0
+/persist/data/gxfp(/.*)?            u:object_r:gx_fpd_data_file:s0
+/data/gf_data(/.*)?                 u:object_r:gx_fpd_data_file:s0
+/data/system/fingerprint(/.*)?      u:object_r:gx_fpd_data_file:s0
+/dev/gf66xx-spi                     u:object_r:gx_fpd_device:s0
+/system/bin/goodixfp                u:object_r:gx_fpd_exec:s0

--- a/sepolicy/fingerprintd.te
+++ b/sepolicy/fingerprintd.te
@@ -3,3 +3,6 @@ allow fingerprintd tee_device:chr_file rw_file_perms;
 allow fingerprintd uhid_device:chr_file rw_file_perms;
 allow fingerprintd firmware_file:dir { search };
 allow fingerprintd firmware_file:file { read open getattr };
+allow fingerprintd default_android_service:service_manager find;
+allow fingerprintd gx_fpd:binder { call transfer };
+allow fingerprintd gx_fpd_service:service_manager find;

--- a/sepolicy/gx_fpd.te
+++ b/sepolicy/gx_fpd.te
@@ -1,0 +1,58 @@
+type gx_fpd, domain;
+type gx_fpd_exec, exec_type, file_type;
+
+# gx_fpd
+init_daemon_domain(gx_fpd)
+binder_use(gx_fpd)
+
+# need to find KeyStore and add self
+allow gx_fpd fingerprintd_service:service_manager { add find };
+
+# allow HAL module to read dir contents
+allow gx_fpd gx_fpd_data_file:file create_file_perms;
+
+# allow HAL module to read/write/unlink contents of this dir
+allow gx_fpd gx_fpd_data_file:dir create_dir_perms;
+
+# Need to add auth tokens to KeyStore
+use_keystore(gx_fpd)
+allow gx_fpd keystore:keystore_key { add_auth };
+
+# For permissions checking
+binder_call(gx_fpd, system_server);
+allow gx_fpd permission_service:service_manager find;
+
+#Allow access to goodix device
+allow gx_fpd gx_fpd_device:chr_file rw_file_perms;
+
+#Allow access to tee device
+allow gx_fpd tee_device:chr_file rw_file_perms;
+
+# Allow access to ion device
+allow gx_fpd ion_device:chr_file rw_file_perms;
+
+#allow create socket
+allow gx_fpd self:socket create_socket_perms;
+allow gx_fpd self:{ netlink_socket netlink_generic_socket } create_socket_perms;
+
+#allow read/write property
+set_prop(gx_fpd, system_prop)
+
+# allow services to communicate
+allow gx_fpd gx_fpd_service:service_manager { add find };
+allow gx_fpd fingerprintd:binder { transfer call };
+allow gx_fpd fingerprint_service:service_manager find;
+allow gx_fpd power_service:service_manager find;
+
+# allow service to read firmware
+r_dir_file(gx_fpd, firmware_file)
+
+# allow services to dump my dickpics apparently (might be incorrect labeling)
+allow gx_fpd fuse:dir search;
+allow gx_fpd fuse:file { getattr open append };
+allow gx_fpd self:capability dac_override;
+allow gx_fpd storage_file:dir search;
+allow gx_fpd storage_file:lnk_file read;
+allow gx_fpd mnt_user_file:dir search;
+allow gx_fpd mnt_user_file:lnk_file read;
+allow gx_fpd tmpfs:dir search;

--- a/sepolicy/service.te
+++ b/sepolicy/service.te
@@ -1,0 +1,1 @@
+type gx_fpd_service, service_manager_type;

--- a/sepolicy/service_contexts
+++ b/sepolicy/service_contexts
@@ -1,0 +1,2 @@
+goodix.fp                              u:object_r:gx_fpd_service:s0
+android.hardware.fingerprint.IGoodixFingerprintDaemon u:object_r:gx_fpd_service:s0

--- a/sepolicy/tee.te
+++ b/sepolicy/tee.te
@@ -1,0 +1,7 @@
+# /data/goodix labeling
+type_transition tee system_data_file:{ dir file } gx_fpd_data_file;
+
+allow tee gx_fpd_data_file:dir create_dir_perms;
+allow tee gx_fpd_data_file:file create_file_perms;
+allow tee system_data_file:dir create_dir_perms;
+allow tee system_data_file:file open;


### PR DESCRIPTION
This fixes goodix fingerprint sensor with this build.

It seems that the ruleset is more permissive that it may be (judging by other device trees) - probably labels for /data/ files are incorrect, but I am glad that it works at all right now, we could improve it later.